### PR TITLE
python: Use deterministic import

### DIFF
--- a/pixelmatch/__init__.py
+++ b/pixelmatch/__init__.py
@@ -1,2 +1,16 @@
-from .core import *
-from .utils import *
+from .core import pixelmatch
+from .utils import antialiased, has_many_siblings, color_delta, rgb2y, rgb2i, rgb2q, blendRGB, blend, draw_pixel, draw_gray_pixel
+
+__all__ = [
+  "pixelmatch",
+  "antialiased",
+  "has_many_siblings",
+  "color_delta",
+  "rgb2y",
+  "rgb2i",
+  "rgb2q",
+  "blendRGB",
+  "blend",
+  "draw_pixel",
+  "draw_gray_pixel",
+]


### PR DESCRIPTION
Adds explicit imports and `__all__` to `__init__.py` to explicitly
mention the methods available to use upon importing the `pixelmatch`
library.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
