### PR TITLE
vscode: Remove sort imports override

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
   "python.pythonPath": ".venv/bin/python3",
-  "python.formatting.provider": "black",
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": false
-  }
+  "python.formatting.provider": "black"
 }


### PR DESCRIPTION
Both issues related to sorting has been resolved upstream in VS Code and
is not occurring anymore.

Related-to: https://github.com/microsoft/vscode-python/issues/9889
Related-to: https://github.com/microsoft/vscode/issues/83586
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
